### PR TITLE
Fix: number type changed to string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "currency-codes" {
   export interface CurrencyCodeRecord {
     code: string;
-    number: number;
+    number: string;
     currency: string;
     countries: string[];
   }
@@ -10,7 +10,7 @@ declare module "currency-codes" {
 
   export function country(country: string): CurrencyCodeRecord[];
 
-  export function number(number: number): CurrencyCodeRecord;
+  export function number(number: string): CurrencyCodeRecord;
 
   export function codes(): string[];
 


### PR DESCRIPTION
Fixes an issue e.g. for '060'.

```javascript
let currencies = require('currency-codes');
console.log(currencies.number('060')); // 'BMD'
console.log(currencies.number(60)); // undefined
```

In Typescript the first log wouldn't be possible due to type errors.