### PR TITLE
fix: Fixing typo that is present in the ISO standard

### DIFF
--- a/data.js
+++ b/data.js
@@ -98,7 +98,7 @@ module.exports = [
     "code": "AZN",
     "number": "944",
     "digits": 2,
-    "currency": "Azerbaijan Manat",
+    "currency": "Azerbaijani Manat",
     "countries": [
       "Azerbaijan"
     ]


### PR DESCRIPTION
I think that https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list_one.xml has Azerbaijan's currency wrong. See: https://en.wikipedia.org/wiki/Azerbaijani_manat