### PR TITLE
update XML location to current value, resync

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ var cc = require('currency-codes');
 console.log(cc.countries());
 
 /*
-[ 
+[
 	'united arab emirates',
 	'afghanistan',
 	...
@@ -166,7 +166,7 @@ $ npm run iso
 > currency-codes@1.5.1 iso:fetch-xml currency-codes
 > node scripts/fetch-iso-4217-xml.js
 
-Downloaded https://www.currency-iso.org/dam/downloads/lists/list_one.xml to iso-4217-list-one.xml
+Downloaded https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml to iso-4217-list-one.xml
 
 > currency-codes@1.5.1 iso:ingest-xml currency-codes
 > node scripts/ingest-iso-4217-xml.js

--- a/data.js
+++ b/data.js
@@ -1,7 +1,7 @@
 /*
 	Follows ISO 4217, https://www.iso.org/iso-4217-currency-codes.html
-	See https://www.currency-iso.org/dam/downloads/lists/list_one.xml
-	Data last updated 2018-08-29
+	See https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml
+	Data last updated 2023-01-01
 */
 
 module.exports = [

--- a/data.js
+++ b/data.js
@@ -458,6 +458,7 @@ module.exports = [
       "Andorra",
       "Austria",
       "Belgium",
+      "Croatia",
       "Cyprus",
       "Estonia",
       "European Union",
@@ -600,15 +601,6 @@ module.exports = [
     "currency": "Lempira",
     "countries": [
       "Honduras"
-    ]
-  },
-  {
-    "code": "HRK",
-    "number": "191",
-    "digits": 2,
-    "currency": "Kuna",
-    "countries": [
-      "Croatia"
     ]
   },
   {
@@ -880,7 +872,7 @@ module.exports = [
     "digits": 2,
     "currency": "Denar",
     "countries": [
-      "Macedonia (The Former Yugoslav Republic Of)"
+      "North Macedonia"
     ]
   },
   {
@@ -1223,6 +1215,15 @@ module.exports = [
     ]
   },
   {
+    "code": "SLE",
+    "number": "925",
+    "digits": 2,
+    "currency": "Leone",
+    "countries": [
+      "Sierra Leone"
+    ]
+  },
+  {
     "code": "SLL",
     "number": "694",
     "digits": 2,
@@ -1345,7 +1346,7 @@ module.exports = [
     "digits": 2,
     "currency": "Turkish Lira",
     "countries": [
-      "Turkey"
+      "Türki̇ye"
     ]
   },
   {
@@ -1417,7 +1418,7 @@ module.exports = [
       "United States Minor Outlying Islands (The)",
       "United States of America (The)",
       "Virgin Islands (British)",
-      "Virgin Islands (U.S.)"
+      "Virgin Islands (u.s.)"
     ]
   },
   {
@@ -1463,6 +1464,15 @@ module.exports = [
     "currency": "Uzbekistan Sum",
     "countries": [
       "Uzbekistan"
+    ]
+  },
+  {
+    "code": "VED",
+    "number": "926",
+    "digits": 2,
+    "currency": "Bolívar Soberano",
+    "countries": [
+      "Venezuela (Bolivarian Republic Of)"
     ]
   },
   {
@@ -1602,7 +1612,7 @@ module.exports = [
     "countries": [
       "Benin",
       "Burkina Faso",
-      "Côte d'Ivoire",
+      "Côte D'ivoire",
       "Guinea-Bissau",
       "Mali",
       "Niger (The)",

--- a/iso-4217-list-one.xml
+++ b/iso-4217-list-one.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2018-08-29">
+<ISO_4217 Pblshd="2023-01-01">
 	<CcyTbl>
 		<CcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -413,9 +413,9 @@
 		</CcyNtry>
 		<CcyNtry>
 			<CtryNm>CROATIA</CtryNm>
-			<CcyNm>Kuna</CcyNm>
-			<Ccy>HRK</Ccy>
-			<CcyNbr>191</CcyNbr>
+			<CcyNm>Euro</CcyNm>
+			<Ccy>EUR</Ccy>
+			<CcyNbr>978</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
@@ -528,6 +528,13 @@
 			<CcyNm>Euro</CcyNm>
 			<Ccy>EUR</Ccy>
 			<CcyNbr>978</CcyNbr>
+			<CcyMnrUnts>2</CcyMnrUnts>
+		</CcyNtry>
+		<CcyNtry>
+			<CtryNm>ESWATINI</CtryNm>
+			<CcyNm>Lilangeni</CcyNm>
+			<Ccy>SZL</Ccy>
+			<CcyNbr>748</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
@@ -986,7 +993,7 @@
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
-			<CtryNm>MACEDONIA (THE FORMER YUGOSLAV REPUBLIC OF)</CtryNm>
+			<CtryNm>NORTH MACEDONIA</CtryNm>
 			<CcyNm>Denar</CcyNm>
 			<Ccy>MKD</Ccy>
 			<CcyNbr>807</CcyNbr>
@@ -1487,6 +1494,13 @@
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
+			<CtryNm>SIERRA LEONE</CtryNm>
+			<CcyNm>Leone</CcyNm>
+			<Ccy>SLE</Ccy>
+			<CcyNbr>925</CcyNbr>
+			<CcyMnrUnts>2</CcyMnrUnts>
+		</CcyNtry>
+		<CcyNtry>
 			<CtryNm>SINGAPORE</CtryNm>
 			<CcyNm>Singapore Dollar</CcyNm>
 			<Ccy>SGD</Ccy>
@@ -1586,13 +1600,6 @@
 			<CcyNm>Norwegian Krone</CcyNm>
 			<Ccy>NOK</Ccy>
 			<CcyNbr>578</CcyNbr>
-			<CcyMnrUnts>2</CcyMnrUnts>
-		</CcyNtry>
-		<CcyNtry>
-			<CtryNm>ESWATINI</CtryNm>
-			<CcyNm>Lilangeni</CcyNm>
-			<Ccy>SZL</Ccy>
-			<CcyNbr>748</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
@@ -1701,7 +1708,7 @@
 			<CcyMnrUnts>3</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
-			<CtryNm>TURKEY</CtryNm>
+			<CtryNm>TÜRKİYE</CtryNm>
 			<CcyNm>Turkish Lira</CcyNm>
 			<Ccy>TRY</Ccy>
 			<CcyNbr>949</CcyNbr>
@@ -1817,6 +1824,13 @@
 			<CcyNm>Bolívar Soberano</CcyNm>
 			<Ccy>VES</Ccy>
 			<CcyNbr>928</CcyNbr>
+			<CcyMnrUnts>2</CcyMnrUnts>
+		</CcyNtry>
+		<CcyNtry>
+			<CtryNm>VENEZUELA (BOLIVARIAN REPUBLIC OF)</CtryNm>
+			<CcyNm>Bolívar Soberano</CcyNm>
+			<Ccy>VED</Ccy>
+			<CcyNbr>926</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>

--- a/iso-4217-publish-date.js
+++ b/iso-4217-publish-date.js
@@ -1,7 +1,7 @@
 /*
 	Follows ISO 4217, https://www.iso.org/iso-4217-currency-codes.html
-	See https://www.currency-iso.org/dam/downloads/lists/list_one.xml
-	Data last updated 2018-08-29
+	See https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml
+	Data last updated 2023-01-01
 */
 
-module.exports = "2018-08-29";
+module.exports = "2023-01-01";

--- a/scripts/fetch-iso-4217-xml.js
+++ b/scripts/fetch-iso-4217-xml.js
@@ -20,7 +20,7 @@ async function download(url, path) {
 }
 
 async function downloadIso() {
-  const url = 'https://www.currency-iso.org/dam/downloads/lists/list_one.xml';
+  const url = 'https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml';
   const path = 'iso-4217-list-one.xml';
 
   try {

--- a/scripts/ingest-iso-4217-xml.js
+++ b/scripts/ingest-iso-4217-xml.js
@@ -70,7 +70,7 @@ fs.readFile(input, function(err, data) {
 
       const preamble = '/*\n' +
         '\tFollows ISO 4217, https://www.iso.org/iso-4217-currency-codes.html\n' +
-        '\tSee https://www.currency-iso.org/dam/downloads/lists/list_one.xml\n' +
+        '\tSee https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml\n' +
         '\tData last updated ' + publishDate + '\n' +
         '*/\n\n';
 


### PR DESCRIPTION
- [the old `list_one.xml` url](https://www.currency-iso.org/dam/downloads/lists/list_one.xml to iso-4217-list-one.xml) is 404'ing. Updated it to the new location.
- re-ran the script to get up-to-date data.