### PR TITLE
Automate ISO data updates

### DIFF
--- a/.github/workflows/update-iso.yml
+++ b/.github/workflows/update-iso.yml
@@ -33,4 +33,7 @@ jobs:
           body: |
             This PR updates the ISO 4217 data by running the `iso` script.
 
-            Please review and merge this PR if everything looks good.
+            Please review and merge it if everything looks good.
+
+            **Todo:**
+            - [ ] Update tests

--- a/.github/workflows/update-iso.yml
+++ b/.github/workflows/update-iso.yml
@@ -1,0 +1,40 @@
+name: Update ISO 4217 Data
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Runs every Monday at midnight UTC
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  update-iso:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run ISO script
+        run: bun run iso
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update ISO 4217 data" || echo "No changes to commit"
+
+      - name: Push changes and create PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: update-iso-4217-data
+          title: "Update ISO 4217 Data"
+          body: "This PR updates the ISO 4217 data by running the `iso` script."
+          commit-message: "chore: update ISO 4217 data"

--- a/.github/workflows/update-iso.yml
+++ b/.github/workflows/update-iso.yml
@@ -32,9 +32,12 @@ jobs:
           git commit -m "Update ISO 4217 data" || echo "No changes to commit"
 
       - name: Push changes and create PR
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: update-iso-4217-data
           title: "Update ISO 4217 Data"
-          body: "This PR updates the ISO 4217 data by running the `iso` script."
+          body: |
+            This PR updates the ISO 4217 data by running the `iso` script.
+
+            Please review and merge this PR if everything looks good.
           commit-message: "chore: update ISO 4217 data"

--- a/.github/workflows/update-iso.yml
+++ b/.github/workflows/update-iso.yml
@@ -24,20 +24,13 @@ jobs:
       - name: Run ISO script
         run: bun run iso
 
-      - name: Commit changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "Update ISO 4217 data" || echo "No changes to commit"
-
-      - name: Push changes and create PR
+      - name: Commit changes and create PR
         uses: peter-evans/create-pull-request@v7
         with:
           branch: update-iso-4217-data
-          title: "Update ISO 4217 Data"
+          commit-message: "chore: update ISO 4217 data"
+          title: Update ISO 4217 Data
           body: |
             This PR updates the ISO 4217 data by running the `iso` script.
 
             Please review and merge this PR if everything looks good.
-          commit-message: "chore: update ISO 4217 data"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 bun.lockb
+bun.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 package-lock.json
-
+bun.lockb


### PR DESCRIPTION
This PR adds a GitHub action to run the `iso` script, commit and create a PR with the result.

It will run every Monday at midnight (totally arbitrary, feel free to challenge this). It can also be triggered manually. 

Example run on my fork: 
- [Action run](https://github.com/adesurirey/currency-codes/actions/runs/14125688092) 
- [Generated pull-request ](https://github.com/adesurirey/currency-codes/pull/10)
