### PR TITLE
Generate data.json instead of data.js for TypeScript compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 package-lock.json
-
+*.tgz

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ console.log(cc.countries());
 ## data
 
 ``` js
-var data = require('currency-codes/data');
+var data = require('currency-codes/data.json');
 console.log(data);
 
 /*

--- a/data.json
+++ b/data.json
@@ -1,10 +1,4 @@
-/*
-	Follows ISO 4217, https://www.iso.org/iso-4217-currency-codes.html
-	See https://www.currency-iso.org/dam/downloads/lists/list_one.xml
-	Data last updated 2025-03-31
-*/
-
-module.exports = [
+[
   {
     "code": "AED",
     "number": "784",
@@ -1705,4 +1699,4 @@ module.exports = [
       "Zimbabwe"
     ]
   }
-];
+]

--- a/iso-4217-list-one.xml
+++ b/iso-4217-list-one.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-06-25">
+<ISO_4217 Pblshd="2025-03-31">
 	<CcyTbl>
 		<CcyNtry>
 			<CtryNm>AFGHANISTAN</CtryNm>
@@ -426,16 +426,9 @@
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
 		<CcyNtry>
-			<CtryNm>CUBA</CtryNm>
-			<CcyNm>Peso Convertible</CcyNm>
-			<Ccy>CUC</Ccy>
-			<CcyNbr>931</CcyNbr>
-			<CcyMnrUnts>2</CcyMnrUnts>
-		</CcyNtry>
-		<CcyNtry>
 			<CtryNm>CURAÇAO</CtryNm>
-			<CcyNm>Netherlands Antillean Guilder</CcyNm>
-			<Ccy>ANG</Ccy>
+			<CcyNm>Caribbean Guilder</CcyNm>
+			<Ccy>XCG</Ccy>
 			<CcyNbr>532</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>
@@ -1502,8 +1495,8 @@
 		</CcyNtry>
 		<CcyNtry>
 			<CtryNm>SINT MAARTEN (DUTCH PART)</CtryNm>
-			<CcyNm>Netherlands Antillean Guilder</CcyNm>
-			<Ccy>ANG</Ccy>
+			<CcyNm>Caribbean Guilder</CcyNm>
+			<Ccy>XCG</Ccy>
 			<CcyNbr>532</CcyNbr>
 			<CcyMnrUnts>2</CcyMnrUnts>
 		</CcyNtry>

--- a/iso-4217-publish-date.js
+++ b/iso-4217-publish-date.js
@@ -1,7 +1,7 @@
 /*
 	Follows ISO 4217, https://www.iso.org/iso-4217-currency-codes.html
 	See https://www.currency-iso.org/dam/downloads/lists/list_one.xml
-	Data last updated 2024-06-25
+	Data last updated 2025-03-31
 */
 
-module.exports = "2024-06-25";
+module.exports = "2025-03-31";

--- a/scripts/ingest-iso-4217-xml.js
+++ b/scripts/ingest-iso-4217-xml.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
+const { join } = require('path');
 const xml2js = require('xml2js');
 
 require('@gouch/to-title-case');
 
 const input = 'iso-4217-list-one.xml';
-const outputDataFile = 'data.js';
 const outputPublishDateFile = 'iso-4217-publish-date.js';
 
 function ingestEntry(entry) {
@@ -74,17 +74,26 @@ fs.readFile(input, function(err, data) {
         '\tData last updated ' + publishDate + '\n' +
         '*/\n\n';
 
-      const dataContent = preamble +
-        'module.exports = ' + JSON.stringify(countries, null, '  ') + ';';
+      const dataContent = JSON.stringify(countries, null, '  ');
 
       const publishDateContent = preamble +
         'module.exports = ' + JSON.stringify(publishDate, null, '  ') + ';';
 
-      fs.writeFile(outputDataFile, dataContent, function(err) {
+      fs.writeFile(join(__dirname, '../data.json'), dataContent, function(err) {
         failOnError(err);
 
-        console.log('Ingested ' + input + ' into ' + outputDataFile);
+        console.log('Ingested ' + input + ' into data.json');
       });
+      // For the compatibility, keep generating data.js until next major update
+      fs.writeFile(
+        join(__dirname, '../data.js'), 
+        `${preamble}module.exports = ${dataContent};`, 
+        function(err) {
+          failOnError(err);
+
+          console.log('Ingested ' + input + ' into data.js.');
+        },
+      );
 
       fs.writeFile(outputPublishDateFile, publishDateContent, function(err) {
         failOnError(err);


### PR DESCRIPTION
Currently, currency-code/data is not typed and does not work with TypeScript code.

<details>
<summary>Example code and `tsc` output</summary>

test.ts
```ts
import currencies from "currency-codes/data";

console.log(currencies.map((currency) => currency.code).join("\n"));
```

Output by `tsc --noEmit`
```
/path/to/project-root/test.ts:1:24
Error: Could not find a declaration file for module 'currency-codes/data'. '/path/to/project-root/node_modules/.pnpm/currency-codes@2.2.0/node_modules/currency-codes/data.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/currency-codes` if it exists or add a new declaration (.d.ts) file containing `declare module 'currency-codes/data';` 
import currencies from "currency-codes/data";

/path/to/project-root/scripts/test.ts:3:29
Error: Parameter 'currency' implicitly has an 'any' type. 

console.log(currencies.map((currency) => currency.code).join("\n"));
```
</details>

This PR generates data.json instead of data.js so that you can import the data in the JSON format.
With this change, you can import the data from TypeScript code as follows:

```ts
import currencies from "currency-codes/data.json" with { type: "json" };
```

data.js is still generated for compatibility. You don't have to bump the major version this time.

I considered converting the entire codebase from JavaScript to TypeScript so that I could generate data.d.ts easily, but because I was not sure if you wanted to do so, I didn't rewrite it this time.